### PR TITLE
16to 19 journey - Additional content

### DIFF
--- a/app/views/beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/la-latp-statements.html
+++ b/app/views/beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/la-latp-statements.html
@@ -205,7 +205,7 @@
                                 <h3 class="bold-small">
                                     <a href="aeb-budget-grant-v22">ESFA funded adult education budget grant for 2022 to 2023 <span class="visuallyhidden">(version 1)</span></a>
                                 </h3>
-                                <span>4 March 2023 version 1</span>  <strong class="govuk-tag govuk-bgred">Updated</strong>
+                                <span>Published: 4 March 2023 version 1</span>  <strong class="govuk-tag govuk-bgred">Updated</strong>
                             </div>     
                             <div class="amount-wrapper ">
                                 <h3 class="bold-small"> £849,742 </h3>
@@ -220,7 +220,7 @@
                             <h3 class="bold-small">
                                 <a href="aeb-budget-contract-services2">ESFA funded adult education budget contract for services for 2022 to 2023 <span class="visuallyhidden">(version 1)</span></a>
                             </h3>
-                            <span>3 March 2023 version 1</span> <strong class="govuk-tag govuk-bgred">Updated</strong>
+                            <span>Published: 3 March 2023 version 1</span> <strong class="govuk-tag govuk-bgred">Updated</strong>
                         </div>     
                         <div class="amount-wrapper">
                             <h3 class="bold-small"> £2,395,872 </h3>
@@ -236,7 +236,7 @@
                             <h3 class="bold-small">
                                 <a href="">16 to 18 traineeships for 2022 to 2023 <span class="visuallyhidden">(version 1)</span></a>
                             </h3>
-                            <span>1 March 2023 version 1</span>
+                            <span>Published: 1 March 2023 version 1</span>
                         </div>     
                         <div class="amount-wrapper">
                             <h3 class="bold-small"> £192,916 </h3>
@@ -266,7 +266,7 @@
                             <h3 class="bold-small">
                                 <a href="">19 to 24 traineeships (2020 procurement) for 2022 to 2023 <span class="visuallyhidden">(version 1)</span></a>
                             </h3>
-                            <span>1 March 2023 version 1</span>
+                            <span>Published: 1 March 2023 version 1</span>
                         </div>     
                         <div class="amount-wrapper">
                             <h3 class="bold-small"> £205,266 </h3>
@@ -285,7 +285,7 @@
                                 <h3 class="bold-small">
                                     <a href="">Advanced learner loans for 2022 to 2023 </a>
                                 </h3>
-                                <span>1 July 2023 version 1 </span>
+                                <span>Published: 1 July 2023 version 1 </span>
                             </div>     
                             <div class="amount-wrapper">
                                 <h3 class="bold-small"> £5,500 </h3>
@@ -310,7 +310,7 @@
                                 <h3 class="bold-small">
                                     <a href="">Apprenticeship carry-in for 2022 to 2023 </a>
                                 </h3>
-                                <span>1 July 2023 version 1</span>
+                                <span>Published: 1 July 2023 version 1</span>
                             </div>     
                             <div class="amount-wrapper">
                                 <h3 class="bold-small"> £1,100 </h3>
@@ -329,7 +329,7 @@
                                 <h3 class="bold-small">
                                     <a href="">Non-levy apprenticeship for 2021 to 2022 </a>
                                 </h3>
-                                <span>1 March 2022 version 1</span>
+                                <span>Published: 1 March 2022 version 1</span>
                             </div>     
                             <div class="amount-wrapper">
                                 <h3 class="bold-small"> £1,187,538 </h3>

--- a/app/views/beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/la-training-statements.html
+++ b/app/views/beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/la-training-statements.html
@@ -208,7 +208,7 @@
                                 <h3 class="bold-small">
                                     <a href="aeb-budget-grant-v12">ESFA funded adult education budget grant for 2022 to 2023 <span class="visuallyhidden">(version 1)</span></a>
                                 </h3>
-                                <span>4 March 2023 version 1</span>  <strong class="govuk-tag govuk-bgred">Updated</strong>
+                                <span>Published: 4 March 2023 version 1</span>  <strong class="govuk-tag govuk-bgred">Updated</strong>
                             </div>     
                             <div class="amount-wrapper ">
                                 <h3 class="bold-small"> £849,742 </h3>
@@ -223,7 +223,7 @@
                             <h3 class="bold-small">
                                 <a href="aeb-budget-contract-services1">ESFA funded adult education budget contract for services for 2022 to 2023 <span class="visuallyhidden">(version 1)</span></a>
                             </h3>
-                            <span>3 March 2023 version 1</span> <strong class="govuk-tag govuk-bgred">Updated</strong>
+                            <span>Published: 3 March 2023 version 1</span> <strong class="govuk-tag govuk-bgred">Updated</strong>
                         </div>     
                         <div class="amount-wrapper">
                             <h3 class="bold-small"> £2,395,872 </h3>
@@ -239,7 +239,7 @@
                             <h3 class="bold-small">
                                 <a href="">16 to 18 traineeships for 2022 to 2023 <span class="visuallyhidden">(version 1)</span></a>
                             </h3>
-                            <span>1 March 2023 version 1</span>
+                            <span>Published: 1 March 2023 version 1</span>
                         </div>     
                         <div class="amount-wrapper">
                             <h3 class="bold-small"> £192,916 </h3>
@@ -270,7 +270,7 @@
                             <h3 class="bold-small">
                                 <a href="">19 to 24 traineeships (2020 procurement) for 2022 to 2023 <span class="visuallyhidden">(version 1)</span></a>
                             </h3>
-                            <span>1 March 2023 version 1</span>
+                            <span>Published: 1 March 2023 version 1</span>
                         </div>     
                         <div class="amount-wrapper">
                             <h3 class="bold-small"> £205,266 </h3>
@@ -290,7 +290,7 @@
                                 <h3 class="bold-small">
                                     <a href="">Advanced learner loans for 2022 to 2023 </a>
                                 </h3>
-                                <span>1 July 2023 version 1 </span>
+                                <span>Published: 1 July 2023 version 1 </span>
                             </div>     
                             <div class="amount-wrapper">
                                 <h3 class="bold-small"> £5,500 </h3>
@@ -315,7 +315,7 @@
                                 <h3 class="bold-small">
                                     <a href="">Apprenticeship carry-in for 2022 to 2023 </a>
                                 </h3>
-                                <span>1 July 2023 version 1</span>
+                                <span>Published: 1 July 2023 version 1</span>
                             </div>     
                             <div class="amount-wrapper">
                                 <h3 class="bold-small"> £1,100 </h3>
@@ -334,7 +334,7 @@
                                 <h3 class="bold-small">
                                     <a href="">Non-levy apprenticeship for 2021 to 2022 </a>
                                 </h3>
-                                <span>1 March 2022 version 1</span>
+                                <span>Published: 1 March 2022 version 1</span>
                             </div>     
                             <div class="amount-wrapper">
                                 <h3 class="bold-small"> £1,187,538 </h3>


### PR DESCRIPTION
Minor content update to include the word 'Published:' before the dates shown in the 19+ allocation statement page in learning provider and LA with both roles