### PR TITLE
Prototype changes for decimalisation

### DIFF
--- a/app/views/beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/child/funding-breakdown-la/12-09-2021-copy.html
+++ b/app/views/beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/child/funding-breakdown-la/12-09-2021-copy.html
@@ -1057,11 +1057,11 @@ Pupil premium
                 </h2>
             </div>
 
-         <!-- This section is likely to be of use in future iterations but we need to get the green-light for testing and deciding on which implementation of variations we'll be using. So for now, as we are in limbo around it, it is removed but made easily acccessible for re-entry later. - MS - 13/05/21 -->
+         <!-- This section is likely to be of use in future iterations but we need to get the green-light for testing and deciding on which implementation of variations we'll be using. So for now, as we are in limbo around it, it is removed but made easily acccessible for re-entry later. - MS - 13/05/21 
          <div class="panel panel-border-narrow govuk-!-margin-bottom-8">
             <p>Changes since your last statement are shown using green up arrows for increases and red down arrows for decreases. The changes are calculated in chronological order, which may not match the order in which statements have been issued.<br>
             <span class="show-on-print"><br>Changes shown in printed statements may change. Your digital statement will always show the most accurate figures.</span></p>
-        </div>
+        </div> -->
 
         <div class="form-group">              
             <section class="form-block attachment embedded">

--- a/app/views/beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/child/funding-breakdown-la/12-09-2021.html
+++ b/app/views/beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/child/funding-breakdown-la/12-09-2021.html
@@ -77,10 +77,10 @@ School sixth form funding: academic year 2023 to 2024
 
             <!-- details -->
 
-            <div class="panel panel-border-narrow govuk-!-margin-bottom-8">
+           <!--<div class="panel panel-border-narrow govuk-!-margin-bottom-8">
                 <p>Changes since your last statement are shown using green up arrows for increases and red down arrows for decreases. The changes are calculated in chronological order, which may not match the order in which statements have been issued.<br>
                 <span class="show-on-print"><br>Changes shown in printed statements may change. Your digital statement will always show the most accurate figures.</span></p>
-            </div>
+            </div> -->
 
             <!-- Print and Save -->
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -130,7 +130,7 @@
 			<br/>
 			<div class="form-group">
 				<span class="bold-medium">
-					Designs (not yet tested/in testing)
+					Designs
 					<ul class="list-bullet">
 						<p>The following work is a combination of content, design and user research outputs spanning multiple sprints and user rounds relating to 16 to 19. Dev, UCD and PO analysis has also been conducted, with development evidence logged.</p>
 						<li><a href="beta/v126-0-0/signed-in/external/allocation-statements/16-to-19/parent/la-start"><span class="bold-medium">16 to 19 parent view (<abbr title="Multi-academy trust">LA</abbr>)</span></a></li>


### PR DESCRIPTION
- Removal of a bit of text within the Index page's 'Designs' title that mentioned '(not tested) as 16to19 is now tested
- Removal of the indented text content displayed at the top of the Schools Sixth Form funding statement mentioning rounding/green up and red down arrows, as this is no longer needed due to users being happy with the 'Rounding differences in your calculations' details component present underneath every table section that included a calculation.